### PR TITLE
feat: send email

### DIFF
--- a/packages/app/src/Domains/Certificates/Hooks/useAddLicense.ts
+++ b/packages/app/src/Domains/Certificates/Hooks/useAddLicense.ts
@@ -24,8 +24,8 @@ export const useAddLicense = () => {
       mutate(
         {
           ...data,
-          startDate: startDate.toString(),
-          endDate: endDate.toString(),
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString(),
           type: Number(type),
         },
         {

--- a/packages/server/src/Application/Services/SendEmail.service.ts
+++ b/packages/server/src/Application/Services/SendEmail.service.ts
@@ -7,7 +7,7 @@ import { emailTemplates } from '../Utils/Email';
 import { IRequestContext } from '../Interfaces';
 import { RequestContext } from '../Entities';
 
-interface IAddLicence extends IRequestContext {
+interface IAddLicense extends IRequestContext {
   certificate: Certificate;
 }
 
@@ -63,10 +63,10 @@ export class SendEmailService {
     }
   }
 
-  async addLincence({ certificate, requestContext }: IAddLicence) {
+  async addLincence({ certificate, requestContext }: IAddLicense) {
     await this.sendEmailToAdmins({
       requestContext,
-      templateFn: emailTemplates.addLicence,
+      templateFn: emailTemplates.addLicense,
       templateArgs: {
         reason: certificate.values.reason,
         currentUser: '',

--- a/packages/server/src/Application/Services/SendEmail.service.ts
+++ b/packages/server/src/Application/Services/SendEmail.service.ts
@@ -1,0 +1,88 @@
+import { Certificate } from '@server/domains/Certificates';
+import { GetAdmins } from '@server/domains/Permissions/Domain/UseCases/GetAdmins.usecase';
+import { GetUser } from '@server/domains/Users';
+import { executeUseCase } from '../Adapters';
+import { EmailSender } from '../Utils';
+import { emailTemplates } from '../Utils/Email';
+import { IRequestContext } from '../Interfaces';
+import { RequestContext } from '../Entities';
+
+interface IAddLicence extends IRequestContext {
+  certificate: Certificate;
+}
+
+interface ISignDocument extends IRequestContext {
+  documentId: number;
+  reason: string;
+}
+
+interface ISendEmailsToAdmin<Targs> extends IRequestContext {
+  templateFn: (args: Targs) => { body: string; subject: string };
+  templateArgs: Targs;
+}
+
+export class SendEmailService {
+  constructor(
+    private readonly _getAdmins: GetAdmins,
+    private readonly _getUser: GetUser,
+  ) {}
+
+  private async getAdmins(requestContext: RequestContext) {
+    return await executeUseCase({
+      useCase: this._getAdmins,
+      requestContext,
+    });
+  }
+
+  private async getCurrentUser(requestContext: RequestContext) {
+    return await executeUseCase({
+      useCase: this._getUser,
+      requestContext,
+      input: requestContext.values.userId,
+    });
+  }
+
+  private async sendEmailToAdmins<Targs>({
+    requestContext,
+    templateFn,
+    templateArgs,
+  }: ISendEmailsToAdmin<Targs>) {
+    const currentUser = await this.getCurrentUser(requestContext);
+    const admins = await this.getAdmins(requestContext);
+
+    if (admins) {
+      const { body, subject } = templateFn({
+        ...templateArgs,
+        currentUser: `${currentUser.values.name} ${currentUser.values.surname}`,
+      });
+      EmailSender({
+        to: admins,
+        body,
+        subject,
+      });
+    }
+  }
+
+  async addLincence({ certificate, requestContext }: IAddLicence) {
+    await this.sendEmailToAdmins({
+      requestContext,
+      templateFn: emailTemplates.addLicence,
+      templateArgs: {
+        reason: certificate.values.reason,
+        currentUser: '',
+      },
+    });
+  }
+
+  async signDocument({ reason, documentId, requestContext }: ISignDocument) {
+    await this.sendEmailToAdmins({
+      requestContext,
+      templateFn: emailTemplates.signDocument,
+      templateArgs: {
+        reason,
+        documentId,
+        currentUser: '',
+      },
+    });
+  }
+}

--- a/packages/server/src/Application/Services/services.app.ts
+++ b/packages/server/src/Application/Services/services.app.ts
@@ -1,0 +1,6 @@
+import { asClass } from 'awilix';
+import { SendEmailService } from './SendEmail.service';
+
+export const servicesApp = () => ({
+  sendEmailService: asClass(SendEmailService),
+});

--- a/packages/server/src/Application/Utils/Email/EmailSender.ts
+++ b/packages/server/src/Application/Utils/Email/EmailSender.ts
@@ -1,0 +1,57 @@
+import { logger } from '@server/utils/pino';
+import axios from 'axios';
+
+const _body = {
+  settings: {
+    smtpServer: process.env.EMAIL_SMTPSERVER,
+    smtpPort: process.env.EMAIL_SMTPPORT,
+    smtpUser: process.env.EMAIL_SMTPUSER,
+    smtpPassword: process.env.EMAIL_SMTPPASSWORD,
+    smtpRequirePass: 'true',
+    smtpConexionType: 'none',
+    token: process.env.EMAIL_TOKEN,
+    cuit: process.env.EMAIL_CUIT,
+  },
+  mailInfo: {
+    address: ['nicoc123@gmail.com'],
+    from: 'gestdoc@macrosistemas.ar',
+    subject: 'Gestdoc - Aviso de una nueva licencia',
+    body: 'Prueba realizada desde GestDoc',
+  },
+  footer: {
+    signature: '',
+    extension: '',
+  },
+};
+
+interface SendEmailProps {
+  to: string[];
+  subject?: string;
+  body: string;
+}
+
+export const EmailSender = async ({ to, body, subject }: SendEmailProps) => {
+  const requestBody = {
+    ..._body,
+    mailInfo: {
+      ..._body.mailInfo,
+      address: to,
+      subject,
+      body,
+    },
+  };
+  try {
+    const response = await axios.post(process.env.EMAIL_HOST!, requestBody, {
+      headers: {
+        'Content-Type': 'application/json', // Agrega el header aquí
+      },
+    });
+
+    logger.info('Email enviado con éxito:', response.data);
+
+    return response.data;
+  } catch (error) {
+    logger.error('Error al enviar el email:', error);
+    throw error;
+  }
+};

--- a/packages/server/src/Application/Utils/Email/EmailsTemplates.ts
+++ b/packages/server/src/Application/Utils/Email/EmailsTemplates.ts
@@ -9,7 +9,7 @@ interface ISignDocument {
   documentId: number;
 }
 
-const addLicence = ({ currentUser, reason }: IAddLincence) => ({
+const addLicense = ({ currentUser, reason }: IAddLincence) => ({
   subject: `[Aviso] Gestdoc - Nueva licencia de ${currentUser}`,
   body: `<h1> Nueva licencia</h1> 
               <p>El empleado <strong> ${currentUser} </strong> agregó una licencia<p>
@@ -32,6 +32,6 @@ const signDocument = ({ currentUser, reason, documentId }: ISignDocument) => ({
 });
 
 export const emailTemplates = {
-  addLicence,
+  addLicense,
   signDocument,
 };

--- a/packages/server/src/Application/Utils/Email/EmailsTemplates.ts
+++ b/packages/server/src/Application/Utils/Email/EmailsTemplates.ts
@@ -1,0 +1,37 @@
+interface IAddLincence {
+  currentUser: string;
+  reason: string;
+}
+
+interface ISignDocument {
+  currentUser: string;
+  reason: string;
+  documentId: number;
+}
+
+const addLicence = ({ currentUser, reason }: IAddLincence) => ({
+  subject: `[Aviso] Gestdoc - Nueva licencia de ${currentUser}`,
+  body: `<h1> Nueva licencia</h1> 
+              <p>El empleado <strong> ${currentUser} </strong> agregó una licencia<p>
+              <h2>Descripción de la licencia</h2>
+              <p>${reason}</p>
+              <hr>
+              <p>Este mail fue enviado de forma automática por <strong><a href="https://docs.macrosistemas.ar/" target="_blank" rel="nofollow">GestDoc</a></strong></p>
+              `,
+});
+
+const signDocument = ({ currentUser, reason, documentId }: ISignDocument) => ({
+  subject: `[Aviso] Gestdoc - Firma bajo no conformidad de ${currentUser}`,
+  body: `<h1> Nueva firma bajo no conformidad</h1> 
+              <p>El empleado <strong>${currentUser}</strong> firmó el documento ${documentId} <p>
+              <h2>Motivo de la firma</h2>
+              <p>${reason}</p>
+              <hr>
+              <p>Este mail fue enviado de forma automática por <strong> <a href="https://docs.macrosistemas.ar/" target="_blank" rel="nofollow">GestDoc</a></strong></p>
+              `,
+});
+
+export const emailTemplates = {
+  addLicence,
+  signDocument,
+};

--- a/packages/server/src/Application/Utils/Email/index.ts
+++ b/packages/server/src/Application/Utils/Email/index.ts
@@ -1,0 +1,2 @@
+export * from './EmailSender';
+export * from './EmailsTemplates';

--- a/packages/server/src/Application/Utils/index.ts
+++ b/packages/server/src/Application/Utils/index.ts
@@ -1,2 +1,3 @@
 export * from './Date';
+export * from './Email/EmailSender';
 export * from './LoadImages';

--- a/packages/server/src/Infrastructure/di/register.ts
+++ b/packages/server/src/Infrastructure/di/register.ts
@@ -1,0 +1,12 @@
+import { servicesApp } from '@server/Application/Services/services.app';
+import { registerDomains } from '@server/domains/register';
+import { container } from '@server/utils/Container';
+import { asValue } from 'awilix';
+import { Express } from 'express';
+
+export const registerDI = (app: Express) =>
+  container.register({
+    app: asValue(app),
+    ...registerDomains(),
+    ...servicesApp(),
+  });

--- a/packages/server/src/domains/Certificates/Application/Certificates.service.ts
+++ b/packages/server/src/domains/Certificates/Application/Certificates.service.ts
@@ -27,6 +27,7 @@ import { convertToDTO } from './digest';
 import { NextFunction, Request, Response } from 'express';
 import { AppendImages } from '../Domain/UseCases/AppendImages.usecases';
 import { GetStatisticsCertificates } from '../Domain/UseCases/GetStatisticsCertificates.usecase';
+import { SendEmailService } from '@server/Application/Services/SendEmail.service';
 
 interface IAddCertificateService extends IRequestContext {
   input: {
@@ -45,6 +46,7 @@ export class CertificatesServices {
     private readonly _appendImages: AppendImages,
     private readonly _getCertificatesByCompany: GetCertificatesByCompany,
     private readonly _getStatistisCertificates: GetStatisticsCertificates,
+    private readonly sendEmailService: SendEmailService,
   ) {}
 
   async getCertificates({
@@ -89,6 +91,11 @@ export class CertificatesServices {
         useCase: this._addCertificate,
         input: _input,
         requestContext,
+      });
+
+      this.sendEmailService.addLincence({
+        requestContext,
+        certificate,
       });
 
       return convertToDTO(certificate);

--- a/packages/server/src/domains/Certificates/Domain/UseCases/AddCertificate.usecases.ts
+++ b/packages/server/src/domains/Certificates/Domain/UseCases/AddCertificate.usecases.ts
@@ -12,7 +12,7 @@ export class AddCertificate implements IUseCase<Certificate> {
     requestContext,
   }: IAddCertificate): Promise<Certificate> {
     try {
-      const certificte = await this.certificatesRepository.addCertificate({
+      const certificate = await this.certificatesRepository.addCertificate({
         certificate: Certificate.create({
           type: CertificateTypes.create({ id: type }),
           startDate,
@@ -22,7 +22,7 @@ export class AddCertificate implements IUseCase<Certificate> {
         requestContext,
       });
 
-      return certificte;
+      return certificate;
     } catch {
       throw new AppError('El certificado no fue agregado');
     }

--- a/packages/server/src/domains/Permissions/Domain/Permissions.repository.ts
+++ b/packages/server/src/domains/Permissions/Domain/Permissions.repository.ts
@@ -16,6 +16,8 @@ export interface IGetRoleByUserRepository extends IRequestContext {
   userId: number;
 }
 
+export interface IGetAdminsRepository extends IRequestContext {}
+
 export interface PermissionsRepository {
   getPermissions(params: IGetPermissionsRepository): Promise<Permissions[]>;
   getRoles(params: IGetRolesRepository): Promise<Roles[]>;
@@ -25,4 +27,5 @@ export interface PermissionsRepository {
   associateUserToRole(params: IAssociateUserToRoleRepository): Promise<void>;
   dissociateUserToRole(params: IDissociateUserToRoleRepository): Promise<void>;
   getRoleByUser(params: IGetRoleByUserRepository): Promise<string | null>;
+  getAdmins(params: IGetAdminsRepository): Promise<string[]>;
 }

--- a/packages/server/src/domains/Permissions/Domain/UseCases/GetAdmins.usecase.ts
+++ b/packages/server/src/domains/Permissions/Domain/UseCases/GetAdmins.usecase.ts
@@ -1,0 +1,18 @@
+import { IUseCase } from '@server/Application/Interfaces/IUseCase';
+import { IGetRoles } from '../Roles.interfaces';
+import { PermissionsRepository } from '../Permissions.repository';
+import { AppError } from '@server/Application';
+
+export class GetAdmins implements IUseCase<string[]> {
+  constructor(private permissionsRepository: PermissionsRepository) {}
+
+  async execute({ requestContext }: IGetRoles): Promise<string[]> {
+    try {
+      return await this.permissionsRepository.getAdmins({
+        requestContext,
+      });
+    } catch (error) {
+      throw new AppError(`No se obtuvieorn los admins: ${error}`);
+    }
+  }
+}

--- a/packages/server/src/domains/Permissions/Infrastructure/Database/PermissionsRepository.implementation.local.DB.ts
+++ b/packages/server/src/domains/Permissions/Infrastructure/Database/PermissionsRepository.implementation.local.DB.ts
@@ -1,6 +1,7 @@
 import {
   IAssociateUserToRoleRepository,
   IDissociateUserToRoleRepository,
+  IGetAdminsRepository,
   IGetPermissionsByUserRepository,
   IGetPermissionsRepository,
   IGetRoleByUserRepository,
@@ -58,5 +59,11 @@ export class PermissionsRepositoryImplementationLocal
     requestContext: _,
   }: IDissociateUserToRoleRepository): Promise<void> {
     return this.Db.dissociateUserToRole(userId);
+  }
+
+  async getAdmins({
+    requestContext: _,
+  }: IGetAdminsRepository): Promise<string[]> {
+    throw new Error('Method not implemented.');
   }
 }

--- a/packages/server/src/domains/Permissions/Infrastructure/Database/PermissionsRepository.implementation.ts
+++ b/packages/server/src/domains/Permissions/Infrastructure/Database/PermissionsRepository.implementation.ts
@@ -2,6 +2,7 @@ import { UserModel } from '@server/domains/Users';
 import {
   IAssociateUserToRoleRepository,
   IDissociateUserToRoleRepository,
+  IGetAdminsRepository,
   IGetPermissionsByUserRepository,
   IGetPermissionsRepository,
   IGetRoleByUserRepository,
@@ -128,5 +129,25 @@ export class PermissionsRepositoryImplementation
     });
 
     return roleName?.denominacion || null;
+  }
+
+  async getAdmins({ requestContext }: IGetAdminsRepository): Promise<string[]> {
+    const users = await UserModel.findAll({
+      where: { id_propietario: requestContext.values.ownerId },
+      include: [
+        {
+          model: Users_RolesModel,
+          as: 'UsersRoles',
+          where: { id_rol: 1 },
+          attributes: [], // Evita traer datos innecesarios de la relación
+        },
+      ],
+    });
+
+    if (!users) {
+      throw new Error(`No se encontraron admins`);
+    }
+
+    return users.map(({ email }) => email);
   }
 }

--- a/packages/server/src/domains/Permissions/Infrastructure/Database/Relations.ts
+++ b/packages/server/src/domains/Permissions/Infrastructure/Database/Relations.ts
@@ -1,6 +1,7 @@
 import { UserModel } from '@server/domains/Users';
 import { PermissionsModel } from './Permissions.model';
 import { RolesModel } from './Roles.model';
+import { Users_RolesModel } from './Users_Roles.model';
 
 PermissionsModel.belongsToMany(RolesModel, {
   through: 'Roles_permisos',
@@ -24,4 +25,14 @@ RolesModel.belongsToMany(UserModel, {
   through: 'Usuarios_roles',
   foreignKey: 'id_rol',
   otherKey: 'id_usuario',
+});
+
+UserModel.hasMany(Users_RolesModel, {
+  foreignKey: 'id_usuario',
+  as: 'UsersRoles',
+});
+
+Users_RolesModel.belongsTo(UserModel, {
+  foreignKey: 'id_usuario',
+  as: 'User',
 });

--- a/packages/server/src/domains/Permissions/permissions.app.ts
+++ b/packages/server/src/domains/Permissions/permissions.app.ts
@@ -10,6 +10,7 @@ import {
 } from './Domain';
 import { PermissionsService } from './Aplication';
 import { PermissionsRepositoryImplementation } from './Infrastructure';
+import { GetAdmins } from './Domain/UseCases/GetAdmins.usecase';
 
 export const permissionsApp = {
   permissionsRepository: asClass(PermissionsRepositoryImplementation),
@@ -20,6 +21,7 @@ export const permissionsApp = {
   _getPermissionsByUser: asClass(GetPermissionsByUser),
   _associateUserToRole: asClass(AssociateUserToRole),
   _getRoleByUser: asClass(GetRoleByUser),
+  _getAdmins: asClass(GetAdmins),
 };
 
 export const permissionsController = () =>

--- a/packages/server/src/domains/Users/Domain/UseCases/ChangePassword.usecase.ts
+++ b/packages/server/src/domains/Users/Domain/UseCases/ChangePassword.usecase.ts
@@ -30,7 +30,7 @@ export class ChangePassword implements IUseCase<void> {
         password: getCryptedPassword(newPassword),
         requestContext,
       });
-    } catch (error) {
+    } catch {
       throw new AppError('No se pudo cambiar la constraseña');
     }
   }

--- a/packages/server/src/domains/Users/Domain/User.entity.ts
+++ b/packages/server/src/domains/Users/Domain/User.entity.ts
@@ -5,6 +5,7 @@ export class User {
   constructor(
     private readonly _mail: UserEmail,
     private readonly _name: UserName,
+    private readonly _surname?: string,
     private readonly _id?: UserId,
     private readonly _password?: UserPassword,
     private readonly _renewPassword?: boolean,
@@ -18,6 +19,7 @@ export class User {
     id,
     mail,
     name,
+    surname,
     password,
     renewPassword = false,
     userImage,
@@ -30,6 +32,7 @@ export class User {
     return new User(
       new UserEmail(mail),
       new UserName(name),
+      surname,
       userId,
       userPassword,
       renewPassword,
@@ -49,6 +52,7 @@ export class User {
       id: this._id?.value,
       mail: this._mail.value,
       name: this._name.value,
+      surname: this._surname,
       renewPassword: this._renewPassword,
       userImage: this._userImage,
       ownerId: this._ownerId,

--- a/packages/server/src/domains/Users/Domain/User.interfaces.ts
+++ b/packages/server/src/domains/Users/Domain/User.interfaces.ts
@@ -40,6 +40,7 @@ export interface IUser {
   id?: number;
   mail: string;
   name: string;
+  surname?: string;
   password?: string;
   renewPassword?: boolean;
   userImage?: string;

--- a/packages/server/src/domains/Users/Infrastructure/Database/Users.model.ts
+++ b/packages/server/src/domains/Users/Infrastructure/Database/Users.model.ts
@@ -1,5 +1,6 @@
 import { CompaniesModel } from '@server/domains/Companies/Infrastructure';
 import { RolesModel } from '@server/domains/Permissions';
+import { Users_RolesModel } from '@server/domains/Permissions/Infrastructure/Database/Users_Roles.model';
 import { sequelize } from '@server/Infrastructure';
 import {
   DataTypes,
@@ -28,6 +29,10 @@ export class UserModel extends Model<
 
   declare readonly CompaniesModel: NonAttribute<
     InferAttributes<CompaniesModel>
+  >;
+
+  declare readonly UsersRoles: NonAttribute<
+    InferAttributes<Users_RolesModel>[]
   >;
 
   declare readonly RolesModels: NonAttribute<RolesModel[]>;

--- a/packages/server/src/domains/Users/Infrastructure/Database/UsersRepository.implementation.ts
+++ b/packages/server/src/domains/Users/Infrastructure/Database/UsersRepository.implementation.ts
@@ -38,8 +38,8 @@ export class UsersRepositoryImplementation implements UserRepository {
       attributes: ['id', 'email', 'nombre'],
       where: whereClause,
     });
-    return users.map(({ id, email, nombre }) =>
-      User.create({ id, mail: email, name: nombre }),
+    return users.map(({ id, email, nombre, apellido }) =>
+      User.create({ id, mail: email, name: nombre, surname: apellido }),
     );
   }
 
@@ -63,8 +63,8 @@ export class UsersRepositoryImplementation implements UserRepository {
     if (!userFound) {
       return null;
     }
-    const { email, nombre } = userFound;
-    return User.create({ id, mail: email, name: nombre });
+    const { email, nombre, apellido } = userFound;
+    return User.create({ id, mail: email, name: nombre, surname: apellido });
   }
 
   async validateUser({

--- a/packages/server/src/domains/register.ts
+++ b/packages/server/src/domains/register.ts
@@ -1,20 +1,15 @@
-import { container } from '@server/utils/Container';
 import { userApp } from './Users';
 import { authApp } from './Auth';
 import { permissionsApp } from './Permissions';
 import { documentsApp } from './Documents';
 import { documentTypesApp } from './DocumentsTypes';
 import { certificatesApp } from './Certificates';
-import { asValue } from 'awilix';
-import { Express } from 'express';
 
-export const registerDomains = (app: Express) =>
-  container.register({
-    app: asValue(app),
-    ...authApp,
-    ...userApp,
-    ...permissionsApp,
-    ...documentsApp,
-    ...documentTypesApp,
-    ...certificatesApp,
-  });
+export const registerDomains = () => ({
+  ...authApp,
+  ...userApp,
+  ...permissionsApp,
+  ...documentsApp,
+  ...documentTypesApp,
+  ...certificatesApp,
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,14 +3,14 @@ import dotenv from 'dotenv';
 dotenv.config();
 import express, { Request, Express, Response } from 'express';
 import { initMiddlewares } from './Infrastructure/Middlewares';
-import { registerDomains } from './domains/register';
 import { InstanceMainRouter } from './Infrastructure/Routes/Router';
 import { initExpress } from './Infrastructure/Express/LoadFiles';
+import { registerDI } from './Infrastructure/di/register';
 
 const app: Express = express();
 const port = process.env.PORT || 5500;
 
-registerDomains(app);
+registerDI(app);
 initMiddlewares(app);
 //** Routes */
 InstanceMainRouter(app);

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "Es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "module": "NodeNext" /* Specify what module code is generated. */,
     "moduleResolution": "NodeNext",
     "outDir": "./dist" /* Specify an output folder for all emitted files. */,
@@ -16,7 +16,7 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "types": ["node", "express"],
-    "lib": ["es6"],
+    "lib": ["ES2021"],
     "emitDecoratorMetadata": true,
     //"allowImportingTsExtensions": true,
     //"emitDeclarationOnly": true,


### PR DESCRIPTION
### Enviar mail a los admins cuando se firma un documento en disconformidad y cuando se agrega una licencia. 


1. Nuevos servicios globales para trabajar funcionalidades cross, como por ejemplo enviar mails. 
2. Nueva carpeta para centralizar la inyección de dependencias. 
3. Templates y funciones más simples para poder enviar mails
4. Nuevo caso de uso para obtener a los admins de la empresa
5. Ahora en el usuario también retorna el apellido